### PR TITLE
[WIP]ダメコン発動検知

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -78,12 +78,12 @@
             $v.empty();
             $v.append(caches.toDom());
         }).handle(/kcsapi\/api_req_map\/(start|next)$/, function (json) {
-            var s = adaptors.sotie(json);
-            caches.onSotie(s);
+            var s = adaptors.sortie(json);
+            caches.onSortie(s);
             var $v = $('#stats');
             $v.empty();
             $v.append(caches.toDom());
-            if (!caches.isSafeSotie()) {
+            if (!caches.isSafeSortie()) {
                 $('#dangerModal').modal('show');
             }
         }).listen();

--- a/js/share/consts.js
+++ b/js/share/consts.js
@@ -1,0 +1,6 @@
+// ハードコーディング(手抜き)
+var consts = {
+    supplyShipTypeId: 15,  // 補給艦の艦種ID
+    repairNormalWeaponId: 42,  // 応急修理要員の武器ID(装備IDではない)
+    repairSpecialWeaponId: 43  // 応急修理女神の武器ID(装備IDではない)
+};

--- a/js/share/models.js
+++ b/js/share/models.js
@@ -92,7 +92,7 @@ models = {
         this.girlId = raw['api_ship_id'];
         this.girl = null;
     },
-    Sotie: function (raw) {
+    Sortie: function (raw) {
         this.cellId = raw['api_no'];
         this.bossCellId = raw['api_bosscell_no'] == null ? -1 : raw['api_bosscell_no'];
     },
@@ -398,7 +398,7 @@ models.Repair.prototype = {
         );
     }
 };
-models.Sotie.prototype = {
+models.Sortie.prototype = {
     isBossCell: function () {
         return this.cellId == this.bossCellId;
     }
@@ -677,10 +677,10 @@ var adaptors = {
     },
     /**
      * @param req/start
-     * @return models.Sotie
+     * @return models.Sortie
      */
-    sotie: function (json) {
-        return new models.Sotie(json['api_data']);
+    sortie: function (json) {
+        return new models.Sortie(json['api_data']);
     },
     /**
      * @param req/battle
@@ -738,13 +738,13 @@ var caches = (function () {
             }).length;
         },
         // 進撃時安全チェック
-        onSotie: function (sotie) {
-            if (sotie.isBossCell()) {
+        onSortie: function (sortie) {
+            if (sortie.isBossCell()) {
                 this.od.approachBoss++;
             }
         },
         // 進撃時安全チェック
-        isSafeSotie: function () {
+        isSafeSortie: function () {
             return !this.isWrecked;
         },
         // 母港帰還時

--- a/view/index.html
+++ b/view/index.html
@@ -65,6 +65,7 @@
 
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="../js/share/consts.js"></script>
 <script type="text/javascript" src="../js/share/lib.js"></script>
 <script type="text/javascript" src="../js/share/utils.js"></script>
 <script type="text/javascript" src="../js/share/handler.js"></script>


### PR DESCRIPTION
- [x]  戦闘用データに、艦隊の保有艦娘データを紐づける
- [x]  自艦隊の艦娘のHPがゼロになった時、紐づいた艦娘データがあれば、所持装備からダメコンを探して使用しようとする
- [x]  戦闘ログへのロギング
- [x]  動作テスト(ダメコン使用はたぶん永遠に行われないので、それ以外の動作の確認)
- [x]  readme.mdの更新

挙動をいろいろヒアリングした感じでは、
- 女神と要員を両方装備していると、要員を優先するらしい。
- 要員発動時のHP回復計算式は以下とのこと。

```
Math.floor(maxHp * 0.2)
```

もうちょっとこのブランチでしばらく使って見て、エラーとか出なければマージしちゃいます。
